### PR TITLE
remove items where sample.total==0 from epsilon, if it is a vector

### DIFF
--- a/R/grake.R
+++ b/R/grake.R
@@ -72,6 +72,9 @@ calibrate.survey.design2<-function(design, formula, population,
     mm<-mm[,!zz]
     population<-population[!zz]
     sample.total<-sample.total[!zz]
+    if(length(epsilon)>0){
+      epsilon <- epsilon[!zz]
+    }
   }
 
     
@@ -187,6 +190,9 @@ calibrate.svyrep.design<-function(design, formula, population,compress=NA,
     mm<-mm[,!zz]
     population<-population[!zz]
     sample.total<-sample.total[!zz]
+    if(length(epsilon)>0){
+      epsilon <- epsilon[!zz]
+    }
   }
   
     


### PR DESCRIPTION
If a epsilon is given in the form of a vector, it should have the same length as population at the beginning. However, when elements of population (and sample.total) are removed, there is a mismatch, this should now be corrected.
